### PR TITLE
修正“Server IP”为一个ipv6地址时的格式问题

### DIFF
--- a/files/root/etc/init.d/speederv2
+++ b/files/root/etc/init.d/speederv2
@@ -70,6 +70,9 @@ start_instance() {
 		return 1
 	fi
 
+	/sbin/validate_data "ip6addr" "$server_ip" >/dev/null 2>&1
+	[ $? -eq 0 ] && server_ip="[$server_ip]"
+
 	procd_open_instance
 	procd_set_param command /usr/bin/speederv2
 	procd_append_param command -c


### PR DESCRIPTION
udpspeeder要求服务器地址是ipv6时，需要用这种格式：`-r'[ipv6]:port'`，ipv6地址两侧需要一对方括号，否则udpspeeder无法识别。
这里简单的修改了一下init.d脚本，如果“Server IP”是ipv6就加上方括号。